### PR TITLE
Python 3.9 type hints

### DIFF
--- a/myExecutor.py
+++ b/myExecutor.py
@@ -12,8 +12,8 @@ from util import renderRequest
 @unreal.uclass()
 class MyExecutor(unreal.MoviePipelinePythonHostExecutor):
 
-    pipeline = unreal.uproperty(unreal.MoviePipeline)
-    job_id = unreal.uproperty(unreal.Text)
+    pipeline: unreal.MoviePipeline = unreal.uproperty(unreal.MoviePipeline)
+    job_id: unreal.Text = unreal.uproperty(unreal.Text)
 
     def _post_init(self):
         """
@@ -21,26 +21,28 @@ class MyExecutor(unreal.MoviePipelinePythonHostExecutor):
 
         Good place to register http callback function
         """
-        self.pipeline = None
-        self.queue = None
-        self.job_id = None
+        self.pipeline: unreal.MoviePipeline = None
+        self.queue: unreal.MoviePipelineQueue = None
+        self.job_id: unreal.Text = None
 
         self.http_response_recieved_delegate.add_function_unique(
-            self,
-            "on_http_response_received"
+            self, "on_http_response_received"
         )
 
     def parse_argument(self):
         """
         Parse commandline arguments that initiated the Executor class
         """
-        (cmd_tokens, cmd_switches, cmd_parameters) = unreal.SystemLibrary.\
-            parse_command_line(unreal.SystemLibrary.get_command_line())
+        (cmd_tokens, cmd_switches, cmd_parameters) = (
+            unreal.SystemLibrary.parse_command_line(
+                unreal.SystemLibrary.get_command_line()
+            )
+        )
 
         self.map_path = cmd_tokens[0]
-        self.job_id = cmd_parameters['JobId']
-        self.seq_path = cmd_parameters['LevelSequence']
-        self.preset_path = cmd_parameters['MoviePipelineConfig']
+        self.job_id = cmd_parameters["JobId"]
+        self.seq_path = cmd_parameters["LevelSequence"]
+        self.preset_path = cmd_parameters["MoviePipelineConfig"]
 
     def add_job(self):
         """
@@ -48,19 +50,20 @@ class MyExecutor(unreal.MoviePipelinePythonHostExecutor):
 
         :return: unreal.MoviePipelineExecutorJob. new render job
         """
-        job = self.queue.allocate_new_job(unreal.MoviePipelineExecutorJob)
+        job: unreal.MoviePipelineExecutorJob = self.queue.allocate_new_job(
+            unreal.MoviePipelineExecutorJob
+        )
         job.map = unreal.SoftObjectPath(self.map_path)
         job.sequence = unreal.SoftObjectPath(self.seq_path)
 
         preset_path = unreal.SoftObjectPath(self.preset_path)
-        u_preset = unreal.SystemLibrary.\
-            conv_soft_obj_path_to_soft_obj_ref(preset_path)
+        u_preset = unreal.SystemLibrary.conv_soft_obj_path_to_soft_obj_ref(preset_path)
         job.set_configuration(u_preset)
 
         return job
 
     @unreal.ufunction(override=True)
-    def execute_delayed(self, queue):
+    def execute_delayed(self, queue: unreal.MoviePipelineQueue):
         """
         Function called once level has loaded
 
@@ -79,15 +82,13 @@ class MyExecutor(unreal.MoviePipelinePythonHostExecutor):
         self.pipeline = unreal.new_object(
             self.target_pipeline_class,
             outer=self.get_last_loaded_world(),
-            base_type=unreal.MoviePipeline
+            base_type=unreal.MoviePipeline,
         )
         self.pipeline.on_movie_pipeline_finished_delegate.add_function_unique(
-            self,
-            "on_job_finished"
+            self, "on_job_finished"
         )
         self.pipeline.on_movie_pipeline_work_finished_delegate.add_function_unique(
-            self,
-            "on_pipeline_finished"
+            self, "on_pipeline_finished"
         )
 
         # create our own queue for single job handling
@@ -109,26 +110,28 @@ class MyExecutor(unreal.MoviePipelinePythonHostExecutor):
             return
 
         status = renderRequest.RenderStatus.in_progress
-        progress = 100 * unreal.MoviePipelineLibrary.\
-            get_completion_percentage(self.pipeline)
-        time_estimate = unreal.MoviePipelineLibrary.\
-            get_estimated_time_remaining(self.pipeline)
+        progress = 100 * unreal.MoviePipelineLibrary.get_completion_percentage(
+            self.pipeline
+        )
+        time_estimate = unreal.MoviePipelineLibrary.get_estimated_time_remaining(
+            self.pipeline
+        )
 
         if not time_estimate:
             time_estimate = unreal.Timespan.MAX_VALUE
 
         days, hours, minutes, seconds, _ = time_estimate.to_tuple()
-        time_estimate = '{}h:{}m:{}s'.format(hours, minutes, seconds)
+        time_estimate = "{}h:{}m:{}s".format(hours, minutes, seconds)
 
         self.send_http_request(
-            '{}/put/{}'.format(client.SERVER_API_URL, self.job_id),
+            "{}/put/{}".format(client.SERVER_API_URL, self.job_id),
             "PUT",
-            '{};{};{}'.format(progress, time_estimate, status),
-            unreal.Map(str, str)
+            "{};{};{}".format(progress, time_estimate, status),
+            unreal.Map(str, str),
         )
 
     @unreal.ufunction(ret=None, params=[int, int, str])
-    def on_http_response_received(self, index, code, message):
+    def on_http_response_received(self, index: int, code: int, message: str):
         """
         Http response received callback
 
@@ -139,7 +142,7 @@ class MyExecutor(unreal.MoviePipelinePythonHostExecutor):
         if code == 200:
             unreal.log(message)
         else:
-            unreal.log_error('something wrong with the server!!')
+            unreal.log_error("something wrong with the server!!")
 
     @unreal.ufunction(override=True)
     def is_rendering(self):
@@ -152,7 +155,7 @@ class MyExecutor(unreal.MoviePipelinePythonHostExecutor):
         return False
 
     @unreal.ufunction(ret=None, params=[unreal.MoviePipeline, bool])
-    def on_job_finished(self, pipeline, is_errored):
+    def on_job_finished(self, pipeline: unreal.MoviePipeline, is_errored: bool):
         """
         Render job finished callback
 
@@ -170,17 +173,17 @@ class MyExecutor(unreal.MoviePipelinePythonHostExecutor):
 
         # update to server
         progress = 100
-        time_estimate = 'N/A'
+        time_estimate = "N/A"
         status = renderRequest.RenderStatus.finished
         self.send_http_request(
-            '{}/put/{}'.format(client.SERVER_API_URL, self.job_id),
+            "{}/put/{}".format(client.SERVER_API_URL, self.job_id),
             "PUT",
-            '{};{};{}'.format(progress, time_estimate, status),
-            unreal.Map(str, str)
+            "{};{};{}".format(progress, time_estimate, status),
+            unreal.Map(str, str),
         )
 
     @unreal.ufunction(ret=None, params=[unreal.MoviePipelineOutputData])
-    def on_pipeline_finished(self, results):
+    def on_pipeline_finished(self, results: unreal.MoviePipelineOutputData):
         """
         Render pipeline/queue finished callback
 
@@ -192,7 +195,7 @@ class MyExecutor(unreal.MoviePipelinePythonHostExecutor):
             for shot_data in output_data.shot_data:
                 render_pass_data = shot_data.render_pass_data
                 for k, v in render_pass_data.items():
-                    if k.name == 'FinalImage':
+                    if k.name == "FinalImage":
                         outputs = v.file_paths
                         # get all final output images
                         # unreal.log(outputs)

--- a/requestSubmitter.py
+++ b/requestSubmitter.py
@@ -3,40 +3,41 @@ Client to submit new render request to server
 """
 
 import logging
+from typing import Dict
 
-from util import client
+from util import client, renderRequest
 
 
 logging.basicConfig(level=logging.INFO)
 LOGGER = logging.getLogger(__name__)
 
 
-def send(d):
+def send(d: Dict):
     """
     Send/Submit a new render request
 
     :param d: dict. a render request serialized as dictionary
     """
-    rrequest = client.add_request(d)
+    rrequest: renderRequest.RenderRequest = client.add_request(d)
     if rrequest:
-        LOGGER.info('request %s sent to server', rrequest.uid)
+        LOGGER.info("request %s sent to server", rrequest.uid)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_job_a = {
-        'name': 'street_seq01',
-        'owner': 'TEST_SUBMITTER_01',
-        'umap_path': '/Game/Cinematics/Street/Level_Cin_Street.Level_Cin_Street',
-        'useq_path': '/Game/Cinematics/Street/Shots/Shot01/LS_Shot_Street_Shot01.LS_Shot_Street_Shot01',
-        'uconfig_path': '/Game/Cinematics/Preset/Test.Test'
+        "name": "street_seq01",
+        "owner": "TEST_SUBMITTER_01",
+        "umap_path": "/Game/Cinematics/Street/Level_Cin_Street.Level_Cin_Street",
+        "useq_path": "/Game/Cinematics/Street/Shots/Shot01/LS_Shot_Street_Shot01.LS_Shot_Street_Shot01",
+        "uconfig_path": "/Game/Cinematics/Preset/Test.Test",
     }
 
     test_job_b = {
-        'name': 'street_seq02',
-        'owner': 'TEST_SUBMITTER_01',
-        'umap_path': '/Game/Cinematics/Street/Level_Cin_Street.Level_Cin_Street',
-        'useq_path': '/Game/Cinematics/Street/Shots/Shot02/LS_Shot_Street_Shot02.LS_Shot_Street_Shot02',
-        'uconfig_path': '/Game/Cinematics/Preset/Test.Test'
+        "name": "street_seq02",
+        "owner": "TEST_SUBMITTER_01",
+        "umap_path": "/Game/Cinematics/Street/Level_Cin_Street.Level_Cin_Street",
+        "useq_path": "/Game/Cinematics/Street/Shots/Shot02/LS_Shot_Street_Shot02.LS_Shot_Street_Shot02",
+        "uconfig_path": "/Game/Cinematics/Preset/Test.Test",
     }
 
     for job in [test_job_a, test_job_b]:

--- a/requestWorker.py
+++ b/requestWorker.py
@@ -3,11 +3,11 @@ Client to work/process render request, which launches executor locally and
 updates status to the server
 """
 
-
 import logging
 import os
 import subprocess
 import time
+from typing import Tuple
 
 from util import client
 from util import renderRequest
@@ -19,12 +19,14 @@ LOGGER = logging.getLogger(__name__)
 MODULE_PATH = os.path.dirname(os.path.abspath(__file__))
 
 # render worker specific configuration
-WORKER_NAME = 'RENDER_MACHINE_01'
-UNREAL_EXE = r'E:\Epic\UE_5.0\Engine\Binaries\Win64\UnrealEditor.exe'
+WORKER_NAME = "RENDER_MACHINE_01"
+UNREAL_EXE = r"E:\Epic\UE_5.0\Engine\Binaries\Win64\UnrealEditor.exe"
 UNREAL_PROJECT = r"E:\Epic\UnrealProjects\SequencerTest\SequencerTest.uproject"
 
 
-def render(uid, umap_path, useq_path, uconfig_path):
+def render(
+    uid: str, umap_path: str, useq_path: str, uconfig_path: str
+) -> Tuple[str, str]:
     """
     Render a job locally using the custom executor (myExecutor.py)
 
@@ -42,55 +44,48 @@ def render(uid, umap_path, useq_path, uconfig_path):
     command = [
         UNREAL_EXE,
         UNREAL_PROJECT,
-
         umap_path,
         "-JobId={}".format(uid),
         "-LevelSequence={}".format(useq_path),
         "-MoviePipelineConfig={}".format(uconfig_path),
-
         # required
         "-game",
         "-MoviePipelineLocalExecutorClass=/Script/MovieRenderPipelineCore.MoviePipelinePythonHostExecutor",
         "-ExecutorPythonClass=/Engine/PythonTypes.MyExecutor",
-
         # render preview
         "-windowed",
         "-resX=1280",
         "-resY=720",
-
         # logging
         "-StdOut",
-        "-FullStdOutLogOutput"
+        "-FullStdOutLogOutput",
     ]
     env = os.environ.copy()
     env["UE_PYTHONPATH"] = MODULE_PATH
     proc = subprocess.Popen(
-        command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env=env
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
     )
     return proc.communicate()
 
 
-if __name__ == '__main__':
-    LOGGER.info('Starting render worker %s', WORKER_NAME)
+if __name__ == "__main__":
+    LOGGER.info("Starting render worker %s", WORKER_NAME)
     while True:
         rrequests = client.get_all_requests()
-        uids = [rrequest.uid for rrequest in rrequests
-                if rrequest.worker == WORKER_NAME and
-                rrequest.status == renderRequest.RenderStatus.ready_to_start]
+        uids = [
+            rrequest.uid
+            for rrequest in rrequests
+            if rrequest.worker == WORKER_NAME
+            and rrequest.status == renderRequest.RenderStatus.ready_to_start
+        ]
 
         # render blocks main loop
         for uid in uids:
-            LOGGER.info('rendering job %s', uid)
+            LOGGER.info("rendering job %s", uid)
 
             rrequest = renderRequest.RenderRequest.from_db(uid)
             output = render(
-                uid,
-                rrequest.umap_path,
-                rrequest.useq_path,
-                rrequest.uconfig_path
+                uid, rrequest.umap_path, rrequest.useq_path, rrequest.uconfig_path
             )
 
             # for debugging
@@ -102,4 +97,4 @@ if __name__ == '__main__':
 
         # check assigned job every 10 sec after previous job has finished
         time.sleep(10)
-        LOGGER.info('current job(s) finished, searching for new job(s)')
+        LOGGER.info("current job(s) finished, searching for new job(s)")

--- a/util/client.py
+++ b/util/client.py
@@ -2,8 +2,8 @@
 Client request utility functions
 """
 
-
 import logging
+from typing import Dict
 import requests
 
 from . import renderRequest
@@ -11,8 +11,8 @@ from . import renderRequest
 
 LOGGER = logging.getLogger(__name__)
 
-SERVER_URL = 'http://127.0.0.1:5000'
-SERVER_API_URL = SERVER_URL + '/api'
+SERVER_URL = "http://127.0.0.1:5000"
+SERVER_API_URL = SERVER_URL + "/api"
 
 
 def get_all_requests():
@@ -22,48 +22,48 @@ def get_all_requests():
     :return: [renderRequest.RenderRequest]. request objects
     """
     try:
-        response = requests.get(SERVER_API_URL+'/get')
+        response = requests.get(SERVER_API_URL + "/get")
     except requests.exceptions.ConnectionError:
-        LOGGER.error('failed to connect to server %s', SERVER_API_URL)
+        LOGGER.error("failed to connect to server %s", SERVER_API_URL)
         return
 
-    results = response.json()['results']
+    results = response.json()["results"]
     return [renderRequest.RenderRequest.from_dict(result) for result in results]
 
 
-def get_request(uid):
+def get_request(uid: str):
     """
     Call a 'GET' method for a specific render request from the server
-    
+
     :param uid: str. request uid
     :return: renderRequest.RenderRequest. request object
     """
     try:
-        response = requests.get(SERVER_API_URL+'/get/{}'.format(uid))
+        response = requests.get(SERVER_API_URL + "/get/{}".format(uid))
     except requests.exceptions.ConnectionError:
-        LOGGER.error('failed to connect to server %s', SERVER_API_URL)
+        LOGGER.error("failed to connect to server %s", SERVER_API_URL)
         return
 
     return renderRequest.RenderRequest.from_dict(response.json())
 
 
-def add_request(d):
+def add_request(d: Dict) -> renderRequest.RenderRequest:
     """
     Call a 'POST' method to add a render request to the server
-    
+
     :param d: dict. render request represented as dictionary
     :return: renderRequest.RenderRequest. request object created
     """
     try:
-        response = requests.post(SERVER_API_URL+'/post', json=d)
+        response = requests.post(SERVER_API_URL + "/post", json=d)
     except requests.exceptions.ConnectionError:
-        LOGGER.error('failed to connect to server %s', SERVER_API_URL)
+        LOGGER.error("failed to connect to server %s", SERVER_API_URL)
         return
-    
+
     return renderRequest.RenderRequest.from_dict(response.json())
 
 
-def remove_request(uid):
+def remove_request(uid: str) -> renderRequest.RenderRequest:
     """
     Call a 'DELETE' method to remove a render request to the server
 
@@ -71,15 +71,17 @@ def remove_request(uid):
     :return: renderRequest.RenderRequest. request object created
     """
     try:
-        response = requests.delete(SERVER_API_URL+'/delete/{}'.format(uid))
+        response = requests.delete(SERVER_API_URL + "/delete/{}".format(uid))
     except requests.exceptions.ConnectionError:
-        LOGGER.error('failed to connect to server %s', SERVER_API_URL)
+        LOGGER.error("failed to connect to server %s", SERVER_API_URL)
         return
-    
+
     return renderRequest.RenderRequest.from_dict(response.json())
 
 
-def update_request(uid, progress=0, status='', time_estimate=''):
+def update_request(
+    uid: str, progress: int = 0, status: str = "", time_estimate: str = ""
+) -> renderRequest.RenderRequest:
     """
     Call a 'PUT' method to update a render request on the server
 
@@ -91,15 +93,15 @@ def update_request(uid, progress=0, status='', time_estimate=''):
     """
     try:
         response = requests.put(
-            SERVER_API_URL+'/put/{}'.format(uid),
+            SERVER_API_URL + "/put/{}".format(uid),
             params={
-                'progress': progress,
-                'status': status,
-                'time_estimate': time_estimate
-            }
+                "progress": progress,
+                "status": status,
+                "time_estimate": time_estimate,
+            },
         )
     except requests.exceptions.ConnectionError:
-        LOGGER.error('failed to connect to server %s', SERVER_API_URL)
+        LOGGER.error("failed to connect to server %s", SERVER_API_URL)
         return
 
     return renderRequest.RenderRequest.from_dict(response.json())

--- a/util/renderRequest.py
+++ b/util/renderRequest.py
@@ -4,6 +4,7 @@ Unreal render job request class for data representation and database operation
 
 import logging
 import socket
+from typing import Dict
 import uuid
 import os
 import json
@@ -14,52 +15,52 @@ LOGGER = logging.getLogger(__name__)
 
 MODULE_PATH = os.path.dirname(os.path.abspath(__file__))
 ROOT_PATH = os.path.dirname(MODULE_PATH)
-DATABASE = os.path.join(ROOT_PATH, 'database')
+DATABASE = os.path.join(ROOT_PATH, "database")
 
 
-class RenderStatus(object):
+class RenderStatus:
     """
     Enum class to represent render job status
     """
 
-    unassigned = 'un-assigned'
-    ready_to_start = 'ready to start'
-    in_progress = 'in progress'
-    finished = 'finished'
-    errored = 'errored'
-    cancelled = 'cancelled'
-    paused = 'paused'
+    unassigned = "un-assigned"
+    ready_to_start = "ready to start"
+    in_progress = "in progress"
+    finished = "finished"
+    errored = "errored"
+    cancelled = "cancelled"
+    paused = "paused"
 
 
-class RenderRequest(object):
+class RenderRequest:
     """
     An object representing request for an Unreal render job sent from a
     machine to the request manager (renderManager.py)
     """
 
     def __init__(
-            self,
-            uid='',
-            name='',
-            owner='',
-            worker='',
-            time_created='',
-            priority=0,
-            category='',
-            tags=[],
-            status='',
-            umap_path='',
-            useq_path='',
-            uconfig_path='',
-            output_path='',
-            width=0,
-            height=0,
-            frame_rate=0,
-            format='',
-            start_frame=0,
-            end_frame=0,
-            time_estimate='',
-            progress=0
+        self,
+        uid="",
+        name="",
+        owner="",
+        worker="",
+        time_created="",
+        priority=0,
+        category="",
+        tags=[],
+        status="",
+        umap_path="",
+        useq_path="",
+        uconfig_path="",
+        output_path="",
+        width=0,
+        height=0,
+        frame_rate=0,
+        format="",
+        start_frame=0,
+        end_frame=0,
+        time_estimate="",
+        progress=0,
     ):
         """
         Initialization
@@ -90,7 +91,9 @@ class RenderRequest(object):
         self.name = name
         self.owner = owner or socket.gethostname()
         self.worker = worker
-        self.time_created = time_created or datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
+        self.time_created = time_created or datetime.now().strftime(
+            "%m/%d/%Y, %H:%M:%S"
+        )
         self.priority = priority or 0
         self.category = category
         self.tags = tags
@@ -102,7 +105,7 @@ class RenderRequest(object):
         self.width = width or 1280
         self.height = height or 720
         self.frame_rate = frame_rate or 30
-        self.format = format or 'JPG'
+        self.format = format or "JPG"
         self.start_frame = start_frame or 0
         self.end_frame = end_frame or 0
         self.length = self.end_frame - self.start_frame
@@ -110,7 +113,7 @@ class RenderRequest(object):
         self.progress = progress
 
     @classmethod
-    def from_db(cls, uid):
+    def from_db(cls, uid: int):
         """
         re-create a request object from database using uid
 
@@ -119,17 +122,17 @@ class RenderRequest(object):
         :param uid: int. unique id from database
         :return: RenderRequest. request object
         """
-        request_file = os.path.join(DATABASE, '{}.json'.format(uid))
-        with open(request_file, 'r') as fp:
+        request_file = os.path.join(DATABASE, "{}.json".format(uid))
+        with open(request_file, "r") as fp:
             try:
                 request_dict = json.load(fp)
             except Exception as e:
-                LOGGER.error('Failed to load request object from db: %s', e)
+                LOGGER.error("Failed to load request object from db: %s", e)
                 return None
         return cls.from_dict(request_dict)
 
     @classmethod
-    def from_dict(cls, d):
+    def from_dict(cls, d: Dict):
         """
         Create a new request object from partial dictionary/json or.
         re-create a request object from function 'to_dict'
@@ -139,27 +142,27 @@ class RenderRequest(object):
         """
         # has to assign a default value of '' or 0 for initialization
         # value to kick-in
-        uid = d.get('uid') or ''
-        name = d.get('name') or ''
-        owner = d.get('owner') or ''
-        worker = d.get('worker') or ''
-        time_created = d.get('time_created') or ''
-        priority = d.get('priority') or 0
-        category = d.get('category') or ''
-        tags = d.get('tags') or []
-        status = d.get('status') or ''
-        umap_path = d.get('umap_path') or ''
-        useq_path = d.get('useq_path') or ''
-        uconfig_path = d.get('uconfig_path') or ''
-        output_path = d.get('output_path') or ''
-        width = d.get('width') or 0
-        height = d.get('height') or 0
-        frame_rate = d.get('frame_rate') or 0
-        format = d.get('format') or ''
-        start_frame = d.get('start_frame') or 0
-        end_frame = d.get('end_frame') or 0
-        time_estimate = d.get('time_estimate') or ''
-        progress = d.get('progress') or 0
+        uid = d.get("uid") or ""
+        name = d.get("name") or ""
+        owner = d.get("owner") or ""
+        worker = d.get("worker") or ""
+        time_created = d.get("time_created") or ""
+        priority = d.get("priority") or 0
+        category = d.get("category") or ""
+        tags = d.get("tags") or []
+        status = d.get("status") or ""
+        umap_path = d.get("umap_path") or ""
+        useq_path = d.get("useq_path") or ""
+        uconfig_path = d.get("uconfig_path") or ""
+        output_path = d.get("output_path") or ""
+        width = d.get("width") or 0
+        height = d.get("height") or 0
+        frame_rate = d.get("frame_rate") or 0
+        format = d.get("format") or ""
+        start_frame = d.get("start_frame") or 0
+        end_frame = d.get("end_frame") or 0
+        time_estimate = d.get("time_estimate") or ""
+        progress = d.get("progress") or 0
 
         return cls(
             uid=uid,
@@ -182,7 +185,7 @@ class RenderRequest(object):
             start_frame=start_frame,
             end_frame=end_frame,
             time_estimate=time_estimate,
-            progress=progress
+            progress=progress,
         )
 
     def to_dict(self):
@@ -203,7 +206,7 @@ class RenderRequest(object):
         """
         remove_db(self.uid)
 
-    def update(self, progress=0, status='', time_estimate=''):
+    def update(self, progress: int = 0, status: str = "", time_estimate: str = ""):
         """
         Update current request progress in the fake database
 
@@ -223,7 +226,7 @@ class RenderRequest(object):
 
         write_db(self.__dict__)
 
-    def assign(self, worker):
+    def assign(self, worker: str):
         """
         Update current request assignment in the fake database
 
@@ -238,6 +241,7 @@ class RenderRequest(object):
 
 # region database utility
 
+
 def read_all():
     """
     Read and convert everything in the database to RenderRequest objects
@@ -246,7 +250,9 @@ def read_all():
     """
     rrequests = list()
     files = os.listdir(DATABASE)
-    uids = [os.path.splitext(os.path.basename(f))[0] for f in files if f.endswith('.json')]
+    uids = [
+        os.path.splitext(os.path.basename(f))[0] for f in files if f.endswith(".json")
+    ]
     for uid in uids:
         rrequest = RenderRequest.from_db(uid)
         rrequests.append(rrequest)
@@ -254,33 +260,34 @@ def read_all():
     return rrequests
 
 
-def remove_db(uid):
+def remove_db(uid: str):
     """
     Remove a RenderRequest object from the database
 
     :param uid: str. request uid
     """
-    os.remove(os.path.join(DATABASE, '{}.json'.format(uid)))
+    os.remove(os.path.join(DATABASE, "{}.json".format(uid)))
 
 
 def remove_all():
     """
     Clear database
     """
-    files = os.path.join(DATABASE, '*.json')
+    files = os.path.join(DATABASE, "*.json")
     for file in files:
         os.remove(file)
 
 
-def write_db(d):
+def write_db(d: Dict):
     """
     Write/overwrite a database entry
 
     :param d: dict. RenderRequest object presented as a dictionary
     """
-    uid = d['uid']
-    LOGGER.info('writing to %s', uid)
-    with open(os.path.join(DATABASE, '{}.json'.format(uid)), 'w') as fp:
+    uid = d["uid"]
+    LOGGER.info("writing to %s", uid)
+    with open(os.path.join(DATABASE, "{}.json".format(uid)), "w") as fp:
         json.dump(d, fp, indent=4)
+
 
 # endregion


### PR DESCRIPTION
Hello, I came across this repository, which was very useful to me, so thank you for the code 😄 

- I noticed there were no python 3.9 type hints, which help me code, especially for the unreal types. (vscode does not understand the comment style type hints).

- I removed the inheritance from (object) in classes, which were used in python 2 but are not needed in python 3.

- I applied the black formatter, but I can remove that if you prefer to only have the type hints and nothing else.

Other considerations that could be useful, but would need a bit of code change so I didn't include it yet (I can if you want it):

- For enumerations in python, you can [Inherit from the Enum class](https://docs.python.org/fr/3/library/enum.html)
```python
from enum import Enum

class RenderStatus(Enum):
    """
    Enum class to represent render job status
    """

    UNASSIGNED = "un-assigned"
    READY_TO_START= "ready to start"
    IN_PROGRESS= "in progress"
    FINISHED = "finished"
    ERRORED = "errored"
    CANCELLED = "cancelled"
    PAUSED = "paused"
```

- For the `RenderRequest` class, you could use a [dataclass](https://docs.python.org/3.9/library/dataclasses.html)
```python
from dataclasses import dataclass
class RenderRequest(dataclass):
    """
    An object representing request for an Unreal render job sent from a
    machine to the request manager (renderManager.py)
    """
    uid: str
    """unique identifier, server as primary key for database"""
    name: str
    """job name"""
    owner: str
    """the name of the submitter"""
    worker: str
    """the name of the worker to render the job"""
etc...
```